### PR TITLE
Add worldship xml generation capability

### DIFF
--- a/carrier.py
+++ b/carrier.py
@@ -133,9 +133,10 @@ class Carrier:
     @classmethod
     def __setup__(cls):
         super(Carrier, cls).__setup__()
-        selection = ('ups', 'UPS')
-        if selection not in cls.carrier_cost_method.selection:
-            cls.carrier_cost_method.selection.append(selection)
+
+        for selection in [('ups', 'UPS'), ('ups_worldship', 'UPS Worldship')]:
+            if selection not in cls.carrier_cost_method.selection:
+                cls.carrier_cost_method.selection.append(selection)
 
         cls._error_messages.update({
             'ups_credentials_required':

--- a/carrier.py
+++ b/carrier.py
@@ -29,6 +29,9 @@ class CarrierConfig:
 
     @classmethod
     def get_carrier_methods_for_domain(cls):
+        """
+        UPS can be used for address validation. So add to the list.
+        """
         res = super(CarrierConfig, cls).get_carrier_methods_for_domain()
         if 'ups' not in res:
             res.append('ups')

--- a/party.py
+++ b/party.py
@@ -10,6 +10,7 @@ from orderedset import OrderedSet
 from lxml import etree
 from logbook import Logger
 
+from ups.worldship_api import WorldShip
 from ups.shipping_package import ShipmentConfirm
 from ups.base import PyUPSException
 from trytond.pool import Pool, PoolMeta
@@ -330,3 +331,46 @@ class Address:
             )
 
         return matches
+
+    def to_worldship_address(self):
+        """
+        Return the dict for worldship address xml
+        """
+        Company = Pool().get('company.company')
+
+        vals = {}
+
+        company_id = Transaction().context.get('company')
+        if not company_id:
+            self.raise_user_error(
+                "ups_field_missing",
+                error_args=('Company', 'context')
+            )
+        company_party = Company(company_id).party
+
+        vals = {
+            'CompanyOrName': company_party.name,
+            'Attention': self.name or self.party.name,
+            'Address1': self.street or '',
+            'Address2': self.streetbis or '',
+            'CountryTerritory': self.country and self.country.code,
+            'PostalCode': self.zip or '',
+            'CityOrTown': self.city or '',
+            'StateProvinceCounty': self.subdivision and self.subdivision.code,
+            'Telephone': digits_only_re.sub('', self.party.phone),
+        }
+        return vals
+
+    def to_worldship_to_address(self):
+        """
+        Return xml object of to address
+        """
+        values = self.to_worldship_address()
+        return WorldShip.ship_to_type(**values)
+
+    def to_worldship_from_address(self):
+        """
+        Return xml object from address
+        """
+        values = self.to_worldship_address()
+        return WorldShip.ship_from_type(**values)


### PR DESCRIPTION
Some services like UPS Worldease only work from their application
called worldship and not through API. So provide a generic API
to generate the XML for a shipment and make it available on the
RPC API.

Interacting with this API will be the job of en external script