### PR TITLE
To address company name should not be own company

### DIFF
--- a/party.py
+++ b/party.py
@@ -367,6 +367,7 @@ class Address:
         Return xml object of to address
         """
         values = self.to_worldship_address()
+        values['CompanyOrName'] = self.name or self.party.name
         return WorldShip.ship_to_type(**values)
 
     def to_worldship_from_address(self):


### PR DESCRIPTION
Fixes issue where the common ancestry of from and to addresses resulted in the to address displaying the company name as the company of the customer too.